### PR TITLE
Sample library

### DIFF
--- a/ports/vcpkg-sample-library/portfile.cmake
+++ b/ports/vcpkg-sample-library/portfile.cmake
@@ -1,0 +1,23 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Microsoft/vcpkg-docs
+    REF "${VERSION}"
+    SHA512 3f206cc2fe61d9c97c82b30852e1e4e6df299d93f6159edd1e56c644fa03ccc4670f7681e356d0e3db898a74e099a1ec531821df5430a7b14d61c743c5aa8c30
+    HEAD_REF cmake-sample-lib
+)
+
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME "my_sample_lib")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/usage" "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" COPYONLY)

--- a/ports/vcpkg-sample-library/usage
+++ b/ports/vcpkg-sample-library/usage
@@ -1,0 +1,4 @@
+vcpkg-sample-library provides CMake targets:
+
+find_package(my_sample_lib CONFIG REQUIRED)
+target_link_libraries(main PRIVATE my_sample_lib::my_sample_lib)

--- a/ports/vcpkg-sample-library/vcpkg.json
+++ b/ports/vcpkg-sample-library/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "vcpkg-sample-library",
+  "version": "1.0.0",
+  "homepage": "https://github.com/microsoft/vcpkg-docs/tree/cmake-sample-lib",
+  "description": "A sample C++ library designed to serve as a foundational example for a tutorial on packaging libraries with vcpkg.",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name" : "vcpkg-cmake",
+      "host" : true
+    },
+    {
+      "name" : "vcpkg-cmake-config",
+      "host" : true
+    },
+    "fmt"
+  ]
+}

--- a/ports/vcpkg-sample-library/vcpkg.json
+++ b/ports/vcpkg-sample-library/vcpkg.json
@@ -1,18 +1,18 @@
 {
   "name": "vcpkg-sample-library",
   "version": "1.0.0",
-  "homepage": "https://github.com/microsoft/vcpkg-docs/tree/cmake-sample-lib",
   "description": "A sample C++ library designed to serve as a foundational example for a tutorial on packaging libraries with vcpkg.",
+  "homepage": "https://github.com/microsoft/vcpkg-docs/tree/cmake-sample-lib",
   "license": "MIT",
   "dependencies": [
+    "fmt",
     {
-      "name" : "vcpkg-cmake",
-      "host" : true
+      "name": "vcpkg-cmake",
+      "host": true
     },
     {
-      "name" : "vcpkg-cmake-config",
-      "host" : true
-    },
-    "fmt"
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8960,6 +8960,10 @@
       "baseline": "2023-03-22",
       "port-version": 0
     },
+    "vcpkg-sample-library": {
+      "baseline": "1.0.0",
+      "port-version": 0
+    },
     "vcpkg-tool-bazel": {
       "baseline": "5.2.0",
       "port-version": 0


### PR DESCRIPTION
- [X] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [X] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [X] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [X] The versioning scheme in `vcpkg.json` matches what upstream says.
- [X] The license declaration in `vcpkg.json` matches what upstream says.
- [X] The installed as the "copyright" file matches what upstream says.
- [X] The source code of the component installed comes from an authoritative source.
- [X] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [X] Only one version is in the new port's versions file.
- [X] Only one version is added to each modified port's versions file.
