### PR TITLE
Sample library 101

### DIFF
--- a/ports/vcpkg-sample-library/portfile.cmake
+++ b/ports/vcpkg-sample-library/portfile.cmake
@@ -1,10 +1,8 @@
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Microsoft/vcpkg-docs
     REF "${VERSION}"
-    SHA512 3f206cc2fe61d9c97c82b30852e1e4e6df299d93f6159edd1e56c644fa03ccc4670f7681e356d0e3db898a74e099a1ec531821df5430a7b14d61c743c5aa8c30
+    SHA512 fc55ce73b9175bdfedd73d9df1e7ed744de7ee3fd4aa51cafce65ee7bd49e56dc68301843c31d2ba017fd362663c25f53bbf56cfd35dbac09520e39b86bc25b8
     HEAD_REF cmake-sample-lib
 )
 

--- a/ports/vcpkg-sample-library/vcpkg.json
+++ b/ports/vcpkg-sample-library/vcpkg.json
@@ -1,18 +1,18 @@
 {
   "name": "vcpkg-sample-library",
   "version": "1.0.1",
-  "homepage": "https://github.com/microsoft/vcpkg-docs/tree/cmake-sample-lib",
   "description": "A sample C++ library designed to serve as a foundational example for a tutorial on packaging libraries with vcpkg.",
+  "homepage": "https://github.com/microsoft/vcpkg-docs/tree/cmake-sample-lib",
   "license": "MIT",
   "dependencies": [
+    "fmt",
     {
-      "name" : "vcpkg-cmake",
-      "host" : true
+      "name": "vcpkg-cmake",
+      "host": true
     },
     {
-      "name" : "vcpkg-cmake-config",
-      "host" : true
-    },
-    "fmt"
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
   ]
 }

--- a/ports/vcpkg-sample-library/vcpkg.json
+++ b/ports/vcpkg-sample-library/vcpkg.json
@@ -1,18 +1,18 @@
 {
   "name": "vcpkg-sample-library",
-  "version": "1.0.0",
-  "description": "A sample C++ library designed to serve as a foundational example for a tutorial on packaging libraries with vcpkg.",
+  "version": "1.0.1",
   "homepage": "https://github.com/microsoft/vcpkg-docs/tree/cmake-sample-lib",
+  "description": "A sample C++ library designed to serve as a foundational example for a tutorial on packaging libraries with vcpkg.",
   "license": "MIT",
   "dependencies": [
-    "fmt",
     {
-      "name": "vcpkg-cmake",
-      "host": true
+      "name" : "vcpkg-cmake",
+      "host" : true
     },
     {
-      "name": "vcpkg-cmake-config",
-      "host": true
-    }
+      "name" : "vcpkg-cmake-config",
+      "host" : true
+    },
+    "fmt"
   ]
 }

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -8961,7 +8961,7 @@
       "port-version": 0
     },
     "vcpkg-sample-library": {
-      "baseline": "1.0.0",
+      "baseline": "1.0.1",
       "port-version": 0
     },
     "vcpkg-tool-bazel": {

--- a/versions/v-/vcpkg-sample-library.json
+++ b/versions/v-/vcpkg-sample-library.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "605326754bb1d9706188d7c977571baa6c951dd7",
+      "version": "1.0.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [X ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ X] SHA512s are updated for each updated download.
- [ X] The "supports" clause reflects platforms that may be fixed by this new version.
- [X ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ X] Any patches that are no longer applied are deleted from the port's directory.
- [ X] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ X] Only one version is added to each modified port's versions file.